### PR TITLE
Print numbers instead of exponents

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 nasm -f win64 -gcv8 -l test.lst test.asm
-gcc test.obj -o test.exe -ggdb
+gcc -nostdlib test.obj -lkernel32 -o test.exe -ggdb
 test

--- a/display.asm
+++ b/display.asm
@@ -1,43 +1,33 @@
 showoff:
-	push 	rbp
-	mov 	rbp, rsp
-
-	xor		rdx, rdx	;Clearing the registers we are going to use
-	xor		r8, r8
-	xor		r9, r9
 	xor		r14, r14
+	xor		r13, r13
 
-	mov		r14, 00		;Loading the first byte of data as a second param. (First param will be the format string)
-	call	convert		;converting digit to the letter
-	mov		dl, al		;rdx - second param
-
-	mov		r14, 01;
-	call	convert
-	mov		r8b, al		;r8 - third param
-	
-	mov		r14, 02;
-	call	convert
-	mov		r9b, al		;r9 - forth param
-
-	; push 	rbp			;save the stack pointer
-	; mov 	rbp, rsp
-	
-	
-	mov		r13, 15		; run thru the rest of the data and push it via the stack
 	loop1:
+		mov	r13b, [stor + r14]
+		lea	rdx, [powers + r13 + r13*4]
+		mov	r8, 5
+		call	print
+		inc	r14
+		test	r14, 3
+		jnz	loop1
+		lea	rdx, [newline]
+		mov	r8, 2
+		call	print
+		cmp	r14, 16
+		jb	loop1
 
-		mov		r14, r13
-		call	convert
-		push	rax
-		dec		r13
-		cmp		r13, 2
-		jne		loop1
+	lea	rdx, [separ]
+	mov	r8, lost-separ
+	call	print
+	lea	rdx, [newline]
+	mov	r8, 2
+	jmp	print ; tailcall
 
-	sub	rsp, 32
-	
-	lea 	rcx, [fmt]	;Load the format string into memory
-	call 	printf		;call printf
-
-
-	leave				;we done for now, thank you!
+print: ; rdx->buffer r8->len
+	mov rcx, [hStdout]
+	lea r9, [input]
+	push 0 ;lpOverlapped
+	sub rsp, 32 ; shadow space
+	call WriteFile
+	add rsp, 40
 	ret

--- a/spawn.asm
+++ b/spawn.asm
@@ -17,7 +17,7 @@ spawn_continue:
     cmp     r14, 15
     jne     spawn_loop
     
-    call    loose
+    call    lose
     
 spawn_done:
     leave


### PR DESCRIPTION
Additionally, no longer depends on clib, so the binary is five times smaller.

Depends on #2 